### PR TITLE
Implemented get_response method for dbt 0.19 compatibilities

### DIFF
--- a/dbt/adapters/vertica/connections.py
+++ b/dbt/adapters/vertica/connections.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 from dbt.adapters.base import Credentials
 from dbt.adapters.sql import SQLConnectionManager
+from dbt.contracts.connection import AdapterResponse
 from dbt.logger import GLOBAL_LOGGER as logger
 import dbt.exceptions
 
@@ -82,6 +83,13 @@ class verticaConnectionManager(SQLConnectionManager):
                 pass
 
         return connection
+
+    @classmethod
+    def get_response(cls, cursor) -> AdapterResponse:
+        return AdapterResponse(
+            _message=str(cursor._message),
+            rows_affected=cursor.rowcount,
+        )
 
     @classmethod
     def get_status(cls, cursor):

--- a/dbt/include/vertica/macros/materializations/seed.sql
+++ b/dbt/include/vertica/macros/materializations/seed.sql
@@ -85,7 +85,7 @@
   {%- set exists_as_view = (old_relation is not none and old_relation.is_view) -%}
 
   {%- set agate_table = load_agate_table() -%}
-  {%- do store_result('agate_table', status='OK', agate_table=agate_table) -%}
+  {%- do store_result('agate_table', response='OK', agate_table=agate_table) -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         ]
     },
     install_requires=[
-        'dbt-core~=0.18.0',
+        'dbt-core>=0.18.0',
         'vertica-python>=0.10.0',
     ]
 )


### PR DESCRIPTION
Hi @mpcarter !
Would be great to update connector for dbt 0.19+ :) 
I catch only one error on update:
```
Running with dbt=0.19.1
Encountered an error:
Can't instantiate abstract class verticaConnectionManager with abstract methods get_response
```
