### PR TITLE
fix max args bug

### DIFF
--- a/dbt/adapters/vertica/impl.py
+++ b/dbt/adapters/vertica/impl.py
@@ -13,7 +13,7 @@ class verticaAdapter(SQLAdapter):
     @classmethod
     def convert_text_type(cls, agate_table, col_idx):
         column = agate_table.columns[col_idx]
-        lens = (len(d.encode("utf-8")) for d in column.values_without_nulls())
+        lens = [len(d.encode("utf-8")) for d in column.values_without_nulls()]
         max_len = max(lens) if lens else 64
         return "varchar({})".format(max_len)
 


### PR DESCRIPTION
Hello.
We get error, when use old version of this driver (0.19.1) and this bug not fixed in this release.

```max() arg is an empty sequence```

This bug was fixed for redshift (https://github.com/dbt-labs/dbt-core/issues/2250)), so we did it too.